### PR TITLE
Fix search routing and simplify header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Footer from './layout/Footer';
 import HeroBanner from './components/Home/HeroBanner';
 import CategoryCardGroup from './components/Home/CategoryCardGroup';
 import CategoryProductsPage from './pages/CategoryProductsPage';
+import SearchResultsPage from './pages/SearchResultPage';
 
 function HomePage() {
   return (
@@ -42,6 +43,7 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/category/:categoryName" element={<CategoryProductsPage />} />
+          <Route path="/search-results" element={<SearchResultsPage />} />
         </Routes>
       </div>
     </Router>

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import React, { useState } from 'react';
 import { FaSearch, FaShoppingCart, FaMapMarkerAlt } from "react-icons/fa";
 import { useNavigate } from 'react-router-dom';
@@ -8,17 +7,9 @@ const Header = () => {
 
    const navigate = useNavigate(); 
 
-   const handleSearch = async () => {
+   const handleSearch = () => {
     if (!searchQuery.trim()) return;
-
-    try {
-      const response = await fetch(`http://localhost:5043/api/product/search?query=${encodeURIComponent(searchQuery)}`);
-      const results = await response.json();
-      console.log('Search results:', results);
-      navigate(`/search-results?query=${encodeURIComponent(searchQuery)}`);
-    } catch (error) {
-      console.error('Error fetching search results:', error);
-    }
+    navigate(`/search-results?query=${encodeURIComponent(searchQuery)}`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- remove unnecessary fetch and duplicate import from `Header`
- add `SearchResultsPage` route to `App`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686dfb123ec883318a7b7f5f00f6d545